### PR TITLE
find submit button to click, because .submit() no longer works

### DIFF
--- a/javascript/ios-web-test.js
+++ b/javascript/ios-web-test.js
@@ -21,7 +21,7 @@ const desiredCaps = {
   browserName:        'safari', 
   deviceGroup:        'KOBITON', 
   deviceName:         deviceName,
-  platformName:       'iOS'
+  platformName:       'iOS',
   platformVersion:    '*'
 }
 

--- a/javascript/ios-web-test.js
+++ b/javascript/ios-web-test.js
@@ -3,9 +3,9 @@ import 'colors'
 import wd from 'wd'
 import {assert} from 'chai'
 
-const username = 'jeromewallace+demo'
-const apiKey = '2a9a1dcf-d503-4437-96dd-7aeb766fc6b6'
-const deviceName ='iPhone*'
+const username = process.env.KOBITON_USERNAME
+const apiKey = process.env.KOBITON_API_KEY
+const deviceName = process.env.KOBITON_DEVICE_NAME || 'iPhone*'
 
 const kobitonServerConfig = {
   protocol: 'https',

--- a/javascript/ios-web-test.js
+++ b/javascript/ios-web-test.js
@@ -3,9 +3,9 @@ import 'colors'
 import wd from 'wd'
 import {assert} from 'chai'
 
-const username = process.env.KOBITON_USERNAME
-const apiKey = process.env.KOBITON_API_KEY
-const deviceName = process.env.KOBITON_DEVICE_NAME || 'iPhone*'
+const username = 'jeromewallace+demo'
+const apiKey = '2a9a1dcf-d503-4437-96dd-7aeb766fc6b6'
+const deviceName ='iPhone*'
 
 const kobitonServerConfig = {
   protocol: 'https',
@@ -22,6 +22,7 @@ const desiredCaps = {
   deviceGroup:        'KOBITON', 
   deviceName:         deviceName,
   platformName:       'iOS'
+  platformVersion:    '*'
 }
 
 let driver
@@ -62,8 +63,8 @@ describe('iOS Web sample', () => {
     .waitForElementByName('q')
     .sendKeys('Kobiton')
     .sleep(3000)
-    .submit()
-    
+    //This will click on the first button in the drop down menu. As Apple/Safari does not allow for a .submit within the search bar
+    driver.findElementByXpath(".//*[@class='sbic sb43']").click();
     let msg = await driver.title()
     assert.include(msg, 'Kobiton')
   })


### PR DESCRIPTION
fix to update the script for recent Safari, submitted on behalf of Jerome Wallace

Jerome noticed this sample script was no longer functional, tested this fix, and proposed it to me. I'm submitting it for review and inclusion to ensure our sample stays good.