### PR TITLE
Add C# Nunit Android App Launch test

### DIFF
--- a/csharp/kobiton-nunit/.gitignore
+++ b/csharp/kobiton-nunit/.gitignore
@@ -1,0 +1,7 @@
+bin/
+obj/
+*.user
+*.suo
+*.cache
+*.log
+.DS_Store

--- a/csharp/kobiton-nunit/Kobiton.NUnit.csproj
+++ b/csharp/kobiton-nunit/Kobiton.NUnit.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/csharp/kobiton-nunit/README.md
+++ b/csharp/kobiton-nunit/README.md
@@ -1,0 +1,15 @@
+# Kobiton C# NUnit Samples
+
+This folder contains modern C# samples using:
+- .NET 8
+- NUnit
+- Appium.WebDriver
+
+## Run
+From this directory:
+
+
+dotnet restore
+dotnet test
+
+

--- a/csharp/kobiton-nunit/tests/AndroidAppLaunchTest.cs
+++ b/csharp/kobiton-nunit/tests/AndroidAppLaunchTest.cs
@@ -1,0 +1,71 @@
+using NUnit.Framework;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Appium;
+using System;
+
+namespace Kobiton.NUnitSamples
+{
+    [TestFixture]
+    public class AndroidAppLaunchTest
+    {
+        private RemoteWebDriver? driver;
+
+        [Test]
+        public void Launch_Android_App_On_Kobiton()
+        {
+            // NOTE: Use placeholders. Do NOT commit real credentials.
+            string username = "YOUR_KOBITON_USERNAME";
+            string apiKey = "YOUR_KOBITON_API_KEY";
+            string hubBase = "https://api.kobiton.com/wd/hub";
+
+            if (username.StartsWith("YOUR_") || apiKey.StartsWith("YOUR_"))
+            {
+                Assert.Ignore("Set YOUR_KOBITON_USERNAME and YOUR_KOBITON_API_KEY before running this test.");
+            }
+
+
+
+
+            var builder = new UriBuilder(hubBase) { UserName = username, Password = apiKey };
+
+            var options = new AppiumOptions();
+
+            // Explicit auth caps (works even when basic auth is present)
+            options.AddAdditionalAppiumOption("kobiton:username", username);
+            options.AddAdditionalAppiumOption("kobiton:accessKey", apiKey);
+
+            // Standard caps
+            options.PlatformName = "Android";
+            options.AutomationName = "UiAutomator2";
+            options.DeviceName = "001 - Pixel 6";           // TODO: update
+            options.PlatformVersion = "12";                 // TODO: update
+            options.App = "kobiton-store:v749318";          // TODO: update
+
+            // Kobiton caps
+            options.AddAdditionalAppiumOption("kobiton:groupId", 13945);                // TODO: update
+            options.AddAdditionalAppiumOption("kobiton:deviceGroup", "ORGANIZATION");   // TODO: update
+            options.AddAdditionalAppiumOption("kobiton:sessionName", "C# NUnit Android App Launch");
+            options.AddAdditionalAppiumOption("kobiton:deviceOrientation", "portrait");
+            options.AddAdditionalAppiumOption("kobiton:captureScreenshots", true);
+            options.AddAdditionalAppiumOption("kobiton:retainDurationInSeconds", 0);
+
+            driver = new RemoteWebDriver(builder.Uri, options);
+            driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
+
+            Console.WriteLine("Session ID: " + driver.SessionId);
+
+            // Basic sanity check that session is alive and we can query page source
+            var src = driver.PageSource;
+            Console.WriteLine("Page source preview: " + src.Substring(0, Math.Min(500, src.Length)));
+
+            Assert.That(src, Is.Not.Empty, "App should launch and page source should not be empty.");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try { driver?.Quit(); } catch { /* ignore cleanup failures */ }
+            driver?.Dispose();
+        }
+    }
+}

--- a/csharp/kobiton-nunit/tests/AndroidAppLaunchTest.cs
+++ b/csharp/kobiton-nunit/tests/AndroidAppLaunchTest.cs
@@ -13,7 +13,7 @@ namespace Kobiton.NUnitSamples
         [Test]
         public void Launch_Android_App_On_Kobiton()
         {
-            // NOTE: Use placeholders. Do NOT commit real credentials.
+            // NOTE: These are placeholders. Update your Username and API key
             string username = "YOUR_KOBITON_USERNAME";
             string apiKey = "YOUR_KOBITON_API_KEY";
             string hubBase = "https://api.kobiton.com/wd/hub";


### PR DESCRIPTION
This PR adds a new C# NUnit-based Android app launch sample
under csharp/kobiton-nunit.

- Uses .NET 8 + NUnit
- Keeps existing MSTest samples untouched
- Includes basic setup and README for running locally
